### PR TITLE
Replace image → imageId in products.jsonl

### DIFF
--- a/products.jsonl
+++ b/products.jsonl
@@ -1,15 +1,15 @@
-{ "title": "CodeCuff", "price": 9.99, "image": "" }
-{ "title": "BinaryBoost", "price": 49.99, "image": "" }
-{ "title": "Code Breaker", "price": 29.99, "image": "" }
-{ "title": "CodeCrafters", "price": 39.99, "image": "" }
-{ "title": "DevLink", "price": 9.99, "image": "" }
-{ "title": "AlgorithmAir", "price": 39.99, "image": "" }
-{ "title": "Binary Brigade", "price": 24.99, "image": "" }
-{ "title": "CodeSole", "price": 39.99, "image": "" }
-{ "title": "SyntaxStrap", "price": 9.99, "image": "" }
-{ "title": "ByteKicks", "price": 39.99, "image": "" }
-{ "title": "Byte Me", "price": 34.99, "image": "" }
-{ "title": "HackHightops", "price": 49.99, "image": "" }
-{ "title": "SyntaxSneakers", "price": 49.99, "image": "" }
-{ "title": "Hello World", "price": 19.99, "image": "" }
-{ "title": "CodeChrono", "price": 9.99, "image": "" }
+{ "title": "CodeCuff", "price": 9.99, "imageId": "" }
+{ "title": "BinaryBoost", "price": 49.99, "imageId": "" }
+{ "title": "Code Breaker", "price": 29.99, "imageId": "" }
+{ "title": "CodeCrafters", "price": 39.99, "imageId": "" }
+{ "title": "DevLink", "price": 9.99, "imageId": "" }
+{ "title": "AlgorithmAir", "price": 39.99, "imageId": "" }
+{ "title": "Binary Brigade", "price": 24.99, "imageId": "" }
+{ "title": "CodeSole", "price": 39.99, "imageId": "" }
+{ "title": "SyntaxStrap", "price": 9.99, "imageId": "" }
+{ "title": "ByteKicks", "price": 39.99, "imageId": "" }
+{ "title": "Byte Me", "price": 34.99, "imageId": "" }
+{ "title": "HackHightops", "price": 49.99, "imageId": "" }
+{ "title": "SyntaxSneakers", "price": 49.99, "imageId": "" }
+{ "title": "Hello World", "price": 19.99, "imageId": "" }
+{ "title": "CodeChrono", "price": 9.99, "imageId": "" }


### PR DESCRIPTION
Hello,

In the video (https://youtu.be/WyS3mF4wJKw?t=296), the `products.jsonl` file contains documents with an `imageId` key, which matches the schema used in this project. However, it does not work when cloning the repo because it uses a key named `image` instead. This PR fixes this.